### PR TITLE
Added Sluts Hole Lane, Norfolk, UK

### DIFF
--- a/rude/js/rude.js
+++ b/rude/js/rude.js
@@ -702,6 +702,12 @@ var places = [
 		lon: 20.516667
 	},
 	{
+		label: 'Sluts Hole Lane, Norfolk, UK',
+		detail: 'Sluts Hole Lane, Besthorpe, Norfolk, UK',
+		lat: 52.526353,
+		lon: 1.05256
+	},
+	{
 		label: 'Spear, Avery, North Carolina, United States',
 		detail: 'Spear, Plumtree, NC 28657, USA',
 		lat: 36.022347,


### PR DESCRIPTION
From [Wikipedia](http://en.wikipedia.org/wiki/Besthorpe,_Norfolk)
"Somewhat notoriously, the village possesses a road known as Sluts Hole Lane, although this is most likely a spelling mistake made by late Victorian census takers which has passed into relatively modern usage. Attempts to restore the original name - Slutch Hole Lane - have been opposed by local historians. 'Slutch' is an old English word meaning slushy or muddy, and as part of the road remains in its original state, it would seem to be the correct term. Furthermore, maps and census documents held at Norwich's Library 'The Forum' prove that it was originally known as Slutch Hole Lane. However, this has not stopped local historians and media from making capital out of the misnomer."

The roadsign has been stolen AGAIN! http://goo.gl/maps/ciesn
