### PR TITLE
Shyte Brook, so named because historically it was full of shyte

### DIFF
--- a/rude/js/rude.js
+++ b/rude/js/rude.js
@@ -732,6 +732,12 @@ var places = [
 		lon: 53.557671
 	},
 	{
+		label: 'Shyte Brook, Shropshire, UK',
+		detail: 'Shyte Brook, Much Wenlock, Shropshire, UK',
+		lat: 52.60904,
+		lon: -2.54582
+	},
+	{
 		label: 'Slut, Vasterbotten, Sweden',
 		detail: 'Slut, Sweden',
 		lat: 64.733333,


### PR DESCRIPTION
See http://shropshire.gov.uk/planningpolicy.nsf/viewAttachments/EWET-93LK4B/$file/FS2.26bi%20Attachment%20to%20accompany%20FS2.26b.pdf , http://www.muchwenlockguide.info/much_wenlock_walk/walk-04.shtml etc.
