### PR TITLE
Changed Shaft, PA label to MD label

### DIFF
--- a/rude/js/rude-geojson.js
+++ b/rude/js/rude-geojson.js
@@ -2177,7 +2177,7 @@ var places = {
                 ]
             },
             "properties": {
-                "label": "Shaft, Pennsylvania, United States",
+                "label": "Shaft, Maryland, United States",
                 "detail": "Borden Shaft, MD 21532, USA",
                 "id": "145"
             }


### PR DESCRIPTION
Changed Borden Shaft label from "Shaft, Pennsylvania, United States" to "Shaft, Maryland, United States".
